### PR TITLE
Update the installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ brew install bgreenwell/doxx/doxx
 cargo install doxx
 ```
 
-#### AUR (Arch Linux)
+#### Arch Linux
+
+```bash
+pacman -S doxx
+```
+
+The AUR package is also available for the development version:
+
 ```bash
 yay -S doxx-git
 ```


### PR DESCRIPTION
Now available as an official package: <https://archlinux.org/packages/extra/x86_64/doxx/> 🥳
