### PR TITLE
Add Conda-Forge installation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ nix profile install github:bgreenwell/doxx
 ```
 *Thanks to [@bobberb](https://github.com/bobberb) for creating the Nix flake!*
 
+#### Conda-Forge (cross-platform)
+```bash
+conda install doxx
+```
+or globally using [Pixi](pixi.sh):
+```bash
+pixi global install doxx
+```
+
 #### Scoop (Windows)
 ```bash
 # Coming soon


### PR DESCRIPTION
Cool idea to have a quick peek!

`doxx` is now also available on `conda-forge`, where it is build from source for various platforms.
This enables it to be distributed within the `conda` ecosystem and conveniently used with for example [pixi](pixi.sh), which replaced my global package manager.

Cheers!