### PR TITLE
add title recognition based on font_size_baseline

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -242,7 +242,11 @@ pub async fn load_document(file_path: &Path, image_options: ImageOptions) -> Res
                         let option_sz = &run.run_property.sz;
                         /*
                             ⚠️⚠️⚠️
-                            11pt is the default font size built into English version of office word, which may not be a good value.
+                            11pt is the default font size of the normal style of English word.
+                            If the user changes the font size of the normal style and updates the document, runproperty.sz cannot track its change.
+                            Therefore, although 11.0pt can cope with most situations, it is not a good solution.
+                            Limited level. I hope this part can provide some help to you.
+
                             The unit of `runproperty.sz` is 1/2 point.
                         */
                         let sz_f32 = match option_sz.as_ref() {

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use core::panic;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -257,7 +258,7 @@ pub async fn load_document(file_path: &Path, image_options: ImageOptions) -> Res
                                 }
                                 None => Some(11.0 as f32),
                             },
-                            None => Some(11.0 as f32),
+                            None => Some(15.0 as f32), // 默认None如果用户没改过字号的话（即使改动字号，也是一样的）
                         };
                         if let Some(val) = sz_f32 {
                             font_size_vec.push(val);
@@ -276,6 +277,7 @@ pub async fn load_document(file_path: &Path, image_options: ImageOptions) -> Res
     if let Some((key, _)) = font_size_haspmap.iter().max_by_key(|entry| entry.1) {
         font_size_base_line = Some(*key as f32 / 100.0)
     }
+    panic!("font_size_base_line: {:?}", font_size_base_line);
 
     // Enhanced content extraction with style information
     for child in &docx.document.children {


### PR DESCRIPTION
I optimized the code with the help of ChatGPT.
Now, if the user does not set the font size explicitly, the program will look for it recursively:

1. Current run properties
2. Paragraph style
3. Document default run properties (`DocDefaults`)
4. Finally, fall back to Word’s default font size (11pt)

After my testing, the program works as expected.

This is a draft PR. due to my limited ability, there may still be edge cases I haven't noticed. Therefore, I keep the code comments and translate them through software, hoping they can help others understand this part of the code.

If you are interested in this function, I hope these notes are useful.

