### PR TITLE
fix: upgrade ratatui-image to v8.0 for Debian packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ arboard = "3.3"
 viuer = "0.7"
 image = "0.25"
 zip = "2.0"
-ratatui-image = "1.0"
+ratatui-image = "8.0"
 
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "fs"] }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,7 +24,7 @@ use std::io;
 use crate::{document::*, Cli};
 use ratatui_image::{picker::Picker, protocol::StatefulProtocol};
 
-type ImageProtocols = Vec<Box<dyn StatefulProtocol>>;
+type ImageProtocols = Vec<StatefulProtocol>;
 
 pub struct App {
     pub document: Document,
@@ -97,19 +97,17 @@ impl App {
     }
 
     fn init_image_support(&mut self) {
-        // Try to initialize picker from termios on Unix, use default on Windows
+        // Try to initialize picker from terminal query on Unix, use font size on Windows
         #[cfg(unix)]
-        let mut picker = if let Ok(p) = Picker::from_termios() {
+        let picker = if let Ok(p) = Picker::from_query_stdio() {
             p
         } else {
             // Fallback to manual font size
-            Picker::new((8, 16))
+            Picker::from_fontsize((8, 16))
         };
 
         #[cfg(not(unix))]
-        let mut picker = Picker::new((8, 16));
-
-        picker.guess_protocol();
+        let picker = Picker::from_fontsize((8, 16));
 
         // Process all images in the document
         for element in &self.document.elements {


### PR DESCRIPTION
Resolves #59

## Changes
- Update ratatui-image dependency from 1.0 to 8.0
- Remove Box<dyn> wrapper from StatefulProtocol (now concrete type)
- Replace Picker::from_termios() with Picker::from_query_stdio()
- Replace Picker::new() with Picker::from_fontsize()
- Remove picker.guess_protocol() call (automatic in v8.0)

This upgrade enables Debian packaging as requested by @nadzyah while maintaining full compatibility with existing functionality.