### PR TITLE
feat: implement layout cache for text wrapping performance

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,7 +20,11 @@ use ratatui::{
 };
 use std::io;
 
-use crate::{document::*, widgets::DocumentWidget, Cli};
+use crate::{
+    document::*,
+    widgets::{DocumentWidget, LayoutCache},
+    Cli,
+};
 use ratatui_image::{picker::Picker, protocol::StatefulProtocol};
 
 type ImageProtocols = Vec<StatefulProtocol>;
@@ -40,6 +44,7 @@ pub struct App {
     pub color_enabled: bool,
     pub image_picker: Option<Picker>,
     pub image_protocols: ImageProtocols,
+    pub layout_cache: LayoutCache,
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +73,7 @@ impl App {
             color_enabled: cli.color,
             image_picker: None,
             image_protocols: Vec::new(),
+            layout_cache: LayoutCache::new(),
         };
 
         // Apply CLI options
@@ -604,7 +610,7 @@ fn render_document(f: &mut Frame, area: Rect, app: &mut App) {
         .current_search_index(app.current_search_index);
 
     // Render the document content (text + images in single pass)
-    doc_widget.render(inner, f, &mut app.image_protocols);
+    doc_widget.render(inner, f, &mut app.image_protocols, &mut app.layout_cache);
     let scrollbar = Scrollbar::default()
         .orientation(ScrollbarOrientation::VerticalRight)
         .begin_symbol(Some("↑"))

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,3 +1,42 @@
 mod document;
 
+use ratatui::text::Line;
+use std::collections::HashMap;
+
 pub use document::DocumentWidget;
+
+/// Cache for wrapped text lines to avoid re-wrapping on every frame
+#[derive(Debug, Default)]
+pub struct LayoutCache {
+    /// Cached wrapped lines: (element_index, terminal_width) -> Vec<Line>
+    cache: HashMap<(usize, u16), Vec<Line<'static>>>,
+    /// Last known terminal width for invalidation
+    last_width: u16,
+}
+
+impl LayoutCache {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+            last_width: 0,
+        }
+    }
+
+    /// Get cached lines for an element, if available
+    pub fn get(&self, element_index: usize, width: u16) -> Option<&Vec<Line<'static>>> {
+        self.cache.get(&(element_index, width))
+    }
+
+    /// Store wrapped lines for an element
+    pub fn insert(&mut self, element_index: usize, width: u16, lines: Vec<Line<'static>>) {
+        self.cache.insert((element_index, width), lines);
+    }
+
+    /// Invalidate cache if terminal width changed
+    pub fn check_width(&mut self, width: u16) {
+        if width != self.last_width {
+            self.cache.clear();
+            self.last_width = width;
+        }
+    }
+}


### PR DESCRIPTION
- Added LayoutCache to store wrapped lines per (element_index, width)
- Cache invalidates automatically when terminal width changes
- Applied to paragraph rendering for significant performance boost
- Paragraphs only re-wrap when:
  * Terminal is resized
  * Search highlighting is active (dynamic content)
- List rendering prepared for caching (reserved parameters)
- All 59 tests passing

Performance impact: Eliminates redundant Unicode segmentation and width calculations on every frame, especially noticeable with large documents or rapid scrolling.