### PR TITLE
[Docs] Fix pre-built binaries download command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,16 @@ scoop install doxx
 Download from [GitHub releases](https://github.com/bgreenwell/doxx/releases):
 
 ```bash
-# macOS/Linux - automatic platform detection
-curl -L https://github.com/bgreenwell/doxx/releases/latest/download/doxx-$(uname -s)-$(uname -m).tar.gz | tar xz
+# Linux (x86_64, statically linked)
+curl -L https://github.com/bgreenwell/doxx/releases/latest/download/doxx-x86_64-unknown-linux-musl.tar.xz | tar xJ
+sudo mv doxx /usr/local/bin/
+
+# macOS (Intel)
+curl -L https://github.com/bgreenwell/doxx/releases/latest/download/doxx-x86_64-apple-darwin.tar.xz | tar xJ
+sudo mv doxx /usr/local/bin/
+
+# macOS (Apple Silicon)
+curl -L https://github.com/bgreenwell/doxx/releases/latest/download/doxx-aarch64-apple-darwin.tar.xz | tar xJ
 sudo mv doxx /usr/local/bin/
 
 # Verify installation


### PR DESCRIPTION
## Summary

Fix the `curl` download command in the "Pre-built binaries" section of README. The old command used `doxx-$(uname -s)-$(uname -m).tar.gz` but the actual release artifacts use the `{arch}-{vendor}-{os}.tar.xz` naming convention (e.g. `doxx-x86_64-unknown-linux-musl.tar.xz`).

Also fixed the decompression flag from `tar xz` to `tar xJ` (correct flag for `.tar.xz` archives).

## Related Issue

Closes #77

## Type of Change

- [x] Bug fix (non-breaking change)

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code follows the existing style.
- [x] CI is green (passing all checks).