### PR TITLE
Standardize README badges to the shared for-the-badge template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # doxx <a href="https://terminaltrove.com/"><img src="https://cdn.terminaltrove.com/media/badges/tool_of_the_week/svg/terminal_trove_tool_of_the_week_green_on_dark_grey_bg.svg" align="right" height="40" /></a>
 
-> `.docx` files in your terminal — no Microsoft Word required
-
 [![CI](https://img.shields.io/github/actions/workflow/status/bgreenwell/doxx/ci.yml?style=for-the-badge)](https://github.com/bgreenwell/doxx/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/doxx.svg?style=for-the-badge)](https://crates.io/crates/doxx)
-[![Downloads](https://img.shields.io/crates/d/doxx?style=for-the-badge)](https://crates.io/crates/doxx)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg?style=for-the-badge&logo=rust)](https://www.rust-lang.org)
-[![Easy Install](https://img.shields.io/badge/Easy%20Install-Homebrew%20%7C%20Scoop-FBB040?style=for-the-badge)](#installation)
+[![Crates.io](https://img.shields.io/crates/v/doxx.svg?style=for-the-badge&color=%232B579A)](https://crates.io/crates/doxx)
+[![Downloads](https://img.shields.io/crates/d/doxx?style=for-the-badge&color=%232B579A)](https://crates.io/crates/doxx)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-%232196F3.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/rust-1.70%2B-%23D34516.svg?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![Easy Install](https://img.shields.io/badge/Easy%20Install-Homebrew%20%7C%20Scoop%20%7C%20WinGet-%23FBB040?style=for-the-badge)](#installation)
 [![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS%20%7C%20Windows-blue?style=for-the-badge)](https://github.com/bgreenwell/doxx/releases/latest)
+
+> `.docx` files in your terminal — no Microsoft Word required
 
 A fast, terminal-native document viewer for Word files. View, search, and export `.docx` documents without leaving your command line.
 


### PR DESCRIPTION
Part of the cross-project badge standardization with lstr and xleak: badges move directly under the H1 (above the tagline), grouped in two rows, with doxx's accent color (Word blue `#2B579A`) on Crates.io/Downloads, License in the shared blue, Rust badge gaining `logoColor=white`, and Easy Install updated to `Homebrew | Scoop | WinGet`. Docs-only.