### PR TITLE
fix(deps): bump ratatui-image to 9.0 without the chafa system dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-image"
-version = "8.0.2"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d8ad028fcbb171d83cfdeaf44df17bf0eae3585bdd7f89bc87af98fc71b0e"
+checksum = "5dbebe428e366c230b2251c7091f2a56ec2bf818d96cdc807f6474428ee09040"
 dependencies = [
  "base64-simd",
  "icy_sixel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ arboard = "3.3"
 viuer = "0.7"
 image = "0.25"
 zip = "2.0"
-ratatui-image = "8.0"
+ratatui-image = { version = "9.0", default-features = false, features = ["image-defaults", "crossterm"] }
 
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "fs"] }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -142,12 +142,12 @@ impl App {
         let picker = if let Ok(p) = Picker::from_query_stdio() {
             p
         } else {
-            // Fallback to manual font size
-            Picker::from_fontsize((8, 16))
+            // Fallback when the terminal doesn't answer the stdio query
+            Picker::halfblocks()
         };
 
         #[cfg(not(unix))]
-        let picker = Picker::from_fontsize((8, 16));
+        let picker = Picker::halfblocks();
 
         // Process all images in the document
         for element in &self.document.elements {


### PR DESCRIPTION
## Summary
- Dependabot's ratatui-image 8.0.2 -> 9.0.0 bump (#92) failed CI on all 3 platforms: 9.0.0 made the `chafa-dyn` feature default, which requires `libchafa` + `pkg-config` at build time.
- doxx only uses `Picker`/`StatefulProtocol`/`StatefulImage` for kitty/iterm2/halfblocks rendering, not chafa, so this disables default features and re-enables just `image-defaults` and `crossterm` (the same set 8.0.2 defaulted to).
- Also swaps the now-deprecated `Picker::from_fontsize((8, 16))` fallback for `Picker::halfblocks()` per upstream's deprecation note (font size is fixed internally at 10x20 instead of 8x16 in that fallback path only; the primary `from_query_stdio` path is unaffected).

Closes #92.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] CI green on this PR