### PR TITLE
docs: declare MSRV and fix the Rust version badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - README now documents the config file, `doxx config` subcommand, keymap presets, and custom key bindings ([#78](https://github.com/bgreenwell/doxx/issues/78))
 - The spacebar can now be bound in `config.toml` via a literal `" "` key or the `"space"` alias
+- Declared minimum supported Rust version (MSRV) of 1.88 in `Cargo.toml` ([#87](https://github.com/bgreenwell/doxx/issues/87))
+
+### Changed
+- README Rust version badge now reflects the actual 1.88+ MSRV instead of a stale 1.70+ ([#87](https://github.com/bgreenwell/doxx/issues/87))
 
 ### Fixed
 - Custom key bindings for the spacebar were silently dropped due to whitespace trimming during config parsing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "doxx"
 version = "0.1.4"
 edition = "2021"
+rust-version = "1.88"
 description = "Terminal document viewer for .docx files"
 license = "MIT"
 repository = "https://github.com/bgreenwell/doxx"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://img.shields.io/crates/d/doxx?style=for-the-badge&color=%232B579A)](https://crates.io/crates/doxx)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-%232196F3.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-1.70%2B-%23D34516.svg?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.88%2B-%23D34516.svg?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![Easy Install](https://img.shields.io/badge/Easy%20Install-Homebrew%20%7C%20Scoop%20%7C%20WinGet-%23FBB040?style=for-the-badge)](#installation)
 [![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS%20%7C%20Windows-blue?style=for-the-badge)](https://github.com/bgreenwell/doxx/releases/latest)
 


### PR DESCRIPTION
## Summary
- Adds `rust-version = "1.88"` to `Cargo.toml` — the dependency tree's actual floor.
- Verified with `cargo +1.88.0 check --all-targets` (passes clean).
- Updates the README badge from the stale `rust-1.70+` to `rust-1.88+`.

Dependabot is already enabled, so once declared, future MSRV drift will surface directly in major-bump PRs.

Closes #87.

## Test plan
- [x] `cargo +1.88.0 check --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`